### PR TITLE
Better getting started instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Video Browser
 What if you could publish video to the world as easily as you can create a new podcast?
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
 
 ## Getting Started
-
-First, run the development server:
+It's easiest to get started with your desktop browser of choice rather than a TV simulator or device.
+We use NextJS to create an ergonomic environment for basic development.
+Run the development server to check it out:
 
 ```bash
 npm run dev
@@ -14,22 +14,39 @@ yarn dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
-You can start editing the page by modifying `pages/index.js`. The page auto-updates as you edit the file.
+If you have changes in mind, you want to familiarize yourself with the `components/` directory.
+Unlike a typical NextJS app, all navigation is done client-side through a custom router defined in `components/vlink.js`.
+You can find out more in #Developing.
 
-[API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.js`.
+To see how the app behaves in an environment closer to a real TV, you need to [install the WebOS tools](https://webostv.developer.lge.com/develop/getting-started/developer-workflow).
+One of those tools is [the WebOS simulator](https://webostv.developer.lge.com/develop/tools/simulator-introduction).
+With it installed, you can use `npm` to launch it and see the app in a more representative environment:
 
-The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
+```bash
+npm run webos
+```
+
+## Developing
+This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+It is currently supported on LG/WebOS TVs and deployed as a [basic web app](https://webostv.developer.lge.com/develop/getting-started/web-app-types#basic-web-app).
+That means there's no service component and all assets have to be bundled up in the package that run on a TV.
+
+The router used by `vlink` requires a map of paths to Components sourced from `components/component-map.js`.
+That file is re-generated every time you run `npm run dev` or `npm run webos`.
+**If you are adding a new Component that will be a navigation target, you have to re-run one of those build targets for it to show up**
 
 ## WebOS
 Quirks of developing on LG's WebOS TVs.
 
 ### Emulator
-"Simple" apps actually run on the `file://` protocol in the emulator. To make things even more interesting, they are run directly out of your filesystem at the path you started the emulator from. That makes domain-relative URLs weird. Instead of `/` resolving to the root of your app, it resolves to the _root of your local filesystem_. I've used `assetPrefix` and `basePrefix` in [next.config.js](next.config.js) to adjust internal paths appropriately.
+"Simple" apps actually run on the `file://` protocol in the emulator. To make things even more interesting, they are run directly out of your filesystem at the path you started the emulator from. That makes domain-relative URLs weird. Instead of `/` resolving to the root of your app, it resolves to the _root of your local filesystem_. I've used a compbination of `assetPrefix` a custom client-side router in `components/vlink.js` to avoid NextJS's routing machinery because it uses domain-relative URLs extensively.
 
 Simple apps operate in a less restrictive security context than a regular browser app. For instance, CORS headers are not required for cross-domain `fetch` requests in the emulator.
+You can disable CORS restrictions by selecting `Develop > Disable Cross-Origin Restricions` in Safari.
+It's [a little more complicated in Chrome](https://stackoverflow.com/questions/3102819/disable-same-origin-policy-in-chrome) but doable.
 
 ### Real Devices
-Domain-relative URLs (e.g. `"/root-level-doc.html"`) cause the app to crash. Relative URLs are not a problem. Also, routing to the top of a directory does not automatically get resolved to `index.html`; be sure to include that explicitly if that is the intent.
+Domain-relative URLs (e.g. `"/root-level-doc.html"`) cause the app to crash. Relative URLs are not a problem. Also, routing to the top of a directory does not automatically get resolved to `index.html`; be sure to include that explicitly if that is the intent. As long as you're navigating the app through `vlink`s, you shouldn't have to worry about this too much.
 
 ## NextJS
 
@@ -37,8 +54,6 @@ To learn more about Next.js, take a look at the following resources:
 
 - [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
 - [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
 
 ## Licenses
 The Silkscreen font is available under the SIL Open Font License:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ One of those tools is [the WebOS simulator](https://webostv.developer.lge.com/de
 With it installed, you can use `npm` to launch it and see the app in a more representative environment:
 
 ```bash
-npm run webos
+npm run lgsim
 ```
 
 ## Developing
@@ -32,8 +32,25 @@ It is currently supported on LG/WebOS TVs and deployed as a [basic web app](http
 That means there's no service component and all assets have to be bundled up in the package that run on a TV.
 
 The router used by `vlink` requires a map of paths to Components sourced from `components/component-map.js`.
-That file is re-generated every time you run `npm run dev` or `npm run webos`.
+That file is re-generated every time you run `npm run dev` or `npm run lgsim`.
 **If you are adding a new Component that will be a navigation target, you have to re-run one of those build targets for it to show up**
+
+### Developing On a TV
+There are a couple pre-requisites before you can try out the app on a real device.
+
+First, you need to [setup an LG developer account](https://webostv.developer.lge.com/develop/getting-started/preparing-lg-account).
+Don't make your password anything too difficult because you'll have to enter it on your TV fairly regularly.
+Then, install the [LG Developer Mode App](https://webostv.developer.lge.com/develop/getting-started/developer-mode-app) and follow the instructions on using `ares-setup-device` to connect your TV.
+Once your TV is connected, run `ares-setup-device` one more time and set your TV as the default device.
+Every few days, you'll need to go back into the Developer Mode App and re-enable development mode or you'll get cryptic errors from all of the `ares` commands.
+If you're confident you're in dev mode and you're getting errors, check that your TV's IP address hasn't changed since you set it up.
+If it has, you can use `ares-setup-device` to update it.
+
+Once all that is ready, update and launch the app:
+
+```bash
+npm run lgtv
+```
 
 ## WebOS
 Quirks of developing on LG's WebOS TVs.

--- a/components/dnav.js
+++ b/components/dnav.js
@@ -102,7 +102,6 @@ export function DNav ({ children }) {
 
   // clear and re-populate the navigation graph
   function update () {
-    const mark = window.performance.mark('update-start')
     graph.current.clear()
 
     const centers = new Map()
@@ -119,11 +118,6 @@ export function DNav ({ children }) {
     for (const entry of centers.entries()) {
       graph.current.set(entry[0], findAdjacents(entry, centers))
     }
-
-    console.log(window.performance.measure('update', {
-      detail: graph.current.size,
-      start: 'update-start'
-    }))
   }
 
   return (<DNavContext.Provider value={update}>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "node scripts/build-components-map.js ; next dev",
     "build": "next build",
     "export": "next export",
     "start": "next start",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "export": "next export",
     "start": "next start",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
-    "webos": "node scripts/build-components-map.js ; VDRA_TV=webos next build && next export && scripts/replace-asset-prefix.sh && ares-launch -s 22 out",
+    "lgsim": "node scripts/build-components-map.js ; VDRA_TV=webos next build && next export && scripts/replace-asset-prefix.sh && ares-launch -s 22 out",
+    "lgtv": "node scripts/build-components-map.js ; VDRA_TV=webos next build && next export && scripts/replace-asset-prefix.sh && ares-launch io.github.dmlap.video-browser",
     "lint": "next lint",
     "cypress": "cypress open"
   },

--- a/src/storage.js
+++ b/src/storage.js
@@ -16,8 +16,15 @@ function useStorage (key) {
 
     setReady(true)
     if (json) {
-      setValues(Object.freeze(JSON.parse(json)))
-      return
+      try {
+        const values = Object.freeze(JSON.parse(json))
+        setValues(values)
+        return
+      } catch (error) {
+        // log an error and then fall through to the empty storage
+        // case
+        console.log('Error retrieving from localStorage', error, json)
+      }
     }
 
     localStorage.setItem(key, '[]')


### PR DESCRIPTION
Update the `dev` script to re-generate the component map and avoid making that an explicit step for first-time users. Add more documentation on how to launch things and the current set of accumulated quirks for developing on WebOS.
